### PR TITLE
Add missing includes to HelperFunctions

### DIFF
--- a/src/HelperFunctions/HelperFunctions.cpp
+++ b/src/HelperFunctions/HelperFunctions.cpp
@@ -31,7 +31,7 @@
 #include "HelperFunctions.h"
 #include "../BaseLib.h"
 #include "sys/resource.h"
-
+#include <random>
 namespace BaseLib
 {
 

--- a/src/HelperFunctions/HelperFunctions.h
+++ b/src/HelperFunctions/HelperFunctions.h
@@ -46,6 +46,8 @@
 #include <pwd.h>
 #include <grp.h>
 
+#include <vector>
+
 #include <gcrypt.h>
 
 namespace BaseLib

--- a/src/HelperFunctions/Math.cpp
+++ b/src/HelperFunctions/Math.cpp
@@ -28,6 +28,7 @@
  * files in the program, then also delete it here.
 */
 
+#include <cmath>
 #include "Math.h"
 #include "HelperFunctions.h"
 


### PR DESCRIPTION
Due to some missing includes, the compilation of the helper functions is not possible.
I'm wondering, why this happens only on my machine with Arch Linux and gcc 6.1.1.
