### PR TITLE
missing integerValue64 assignment

### DIFF
--- a/src/Encoding/JsonDecoder.cpp
+++ b/src/Encoding/JsonDecoder.cpp
@@ -871,6 +871,7 @@ void JsonDecoder::decodeNumber(const std::vector<char>& json, uint32_t& pos, std
 	else
 	{
 		value->integerValue = minus ? -number : number;
+		value->integerValue64 = value->integerValue;
 		value->floatValue = value->integerValue;
 	}
 }


### PR DESCRIPTION
Assign integerValue to integerValue64 in JsonDecoder::decodeNumber function