### PR TITLE
increase max length of serialnumber to 37 chars

### DIFF
--- a/src/Systems/Peer.cpp
+++ b/src/Systems/Peer.cpp
@@ -399,7 +399,7 @@ void Peer::setID(uint64_t id) {
 }
 
 void Peer::setSerialNumber(std::string serialNumber) {
-  if (serialNumber.length() > 24) return;
+  if (serialNumber.length() > 37) return;
   _serialNumber = serialNumber;
   if (serviceMessages) serviceMessages->setPeerSerial(serialNumber);
   if (_peerID > 0) save(true, false, false);


### PR DESCRIPTION
Increase the maximum length of the serialnumber to 37 characters to
allow uuid as a serialnumber. 37 characters because uuid (36 chars) and
one for a possible star prefix ('*') for group/room peers.