### PR TITLE
Added Optcode::close

### DIFF
--- a/src/Encoding/WebSocket.cpp
+++ b/src/Encoding/WebSocket.cpp
@@ -65,12 +65,15 @@ uint32_t WebSocket::process(char* buffer, int32_t bufferLength)
         processedBytes += processHeader(&buffer, bufferLength);
         if(!_header.parsed) return processedBytes;
     }
-    if(_header.length == 0 || _header.rsv1 || _header.rsv2 || _header.rsv3 || (_header.opcode != Header::Opcode::continuation && _header.opcode != Header::Opcode::text  && _header.opcode != Header::Opcode::binary && _header.opcode != Header::Opcode::ping && _header.opcode != Header::Opcode::pong))
+    if(_header.length == 0 || _header.rsv1 || _header.rsv2 || _header.rsv3 || (_header.opcode != Header::Opcode::continuation && _header.opcode != Header::Opcode::text  && _header.opcode != Header::Opcode::binary && _header.opcode != Header::Opcode::close && _header.opcode != Header::Opcode::ping && _header.opcode != Header::Opcode::pong))
     {
         _header.close = true;
         _dataProcessingStarted = true;
-        setFinished();
-        return processedBytes;
+        if(_header.opcode != Header::Opcode::close)
+	    {
+            setFinished();
+            return processedBytes;
+        }
     }
     _dataProcessingStarted = true;
     processedBytes += processContent(buffer, bufferLength);


### PR DESCRIPTION
See this exampe Websocket packet i received from a Websocket Server

0x881103E86E6F726D616C6C7920636C6F736564 -> ��normally closed 
0x88 		                                                        -> finish = true & optcode = close
   0x11 	                                                                -> 17 Byte Payload Length
      0x03E8                                                               -> 1000 = Websocket Close Code
             0x6E6F726D616C6C7920636C6F736564    -> normally closed
looks like a correct packet
the ignoring of optcode::close result in returning processedBytes = 2
in my case this results in a loop that parses the given Packet several times until the processesBytes > packet.size()

Please see this changes. I'm not sure if this is the best solution to solve this problem.