### PR TITLE
add json rpc member params can be of type object

### DIFF
--- a/src/Encoding/JsonEncoder.cpp
+++ b/src/Encoding/JsonEncoder.cpp
@@ -49,6 +49,21 @@ void JsonEncoder::encodeRequest(std::string &methodName, std::shared_ptr<std::li
   encode(methodCall, encodedData);
 }
 
+void JsonEncoder::encodeRequest(std::string &methodName, std::shared_ptr<Variable> &parameters, std::vector<char> &encodedData) {
+  std::shared_ptr<Variable> methodCall(new Variable(VariableType::tStruct));
+  methodCall->structValue->insert(StructElement("jsonrpc", std::shared_ptr<Variable>(new Variable(std::string("2.0")))));
+  methodCall->structValue->insert(StructElement("method", std::shared_ptr<Variable>(new Variable(methodName))));
+  if(parameters->type == VariableType::tStruct || parameters->type == VariableType::tArray) {
+    methodCall->structValue->insert(StructElement("params", parameters));
+  } else {
+    std::shared_ptr<Variable> params(new Variable(VariableType::tArray));
+    params->arrayValue->push_back(parameters);
+    methodCall->structValue->insert(StructElement("params", params));
+  }
+  methodCall->structValue->insert(StructElement("id", std::shared_ptr<Variable>(new Variable(_requestId++))));
+  encode(methodCall, encodedData);
+}
+
 void JsonEncoder::encodeResponse(const std::shared_ptr<Variable> &variable, int32_t id, std::vector<char> &json) {
   std::shared_ptr<Variable> response(new Variable(VariableType::tStruct));
   response->structValue->insert(StructElement("jsonrpc", std::shared_ptr<Variable>(new Variable(std::string("2.0")))));

--- a/src/Encoding/JsonEncoder.h
+++ b/src/Encoding/JsonEncoder.h
@@ -56,6 +56,7 @@ class JsonEncoder {
   static std::string encode(const std::shared_ptr<Variable> &variable);
   static std::vector<char> encodeBinary(const std::shared_ptr<Variable> &variable);
   void encodeRequest(std::string &methodName, std::shared_ptr<std::list<std::shared_ptr<Variable>>> &parameters, std::vector<char> &encodedData);
+  void encodeRequest(std::string &methodName, std::shared_ptr<Variable> &parameters, std::vector<char> &encodedData);
   static void encodeResponse(const std::shared_ptr<Variable> &variable, int32_t id, std::vector<char> &json);
   static void encodeMQTTResponse(const std::string &methodName, const std::shared_ptr<Variable> &variable, int32_t id, std::vector<char> &json);
 


### PR DESCRIPTION
The current implementation of `JsonEncoder::encodeRequest` only allows that the `params` member is of type array. According to the definition of JSON-RPC, it is also allowed that `params` is an object. This pull request overloads the `encodeRequest` method and takes instead of a list of `BaseLib::Variable`, directly a `BaseLib::Variable` as parameters to allow a passing of type `tStruct` to be encoded as a Json object. If the type is `tArray` it will be encoded as an array and if the type is e.g. `tString`, `tBool`, `tInteger`, etc., a new array is created and the passing is appended. 
This should make the method a bit more flexible without causing any breaking changes.