### PR TITLE
Add libgnutls30 as option to fulfill the gnutls dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://homegear.eu
 
 Package: libhomegear-base
 Architecture: any
-Depends: ${misc:Depends}, libgcrypt20, libgnutlsxx28 | libgnutlsxx30, libgpg-error0 (>= 1.10), zlib1g, libc1-net
+Depends: ${misc:Depends}, libgcrypt20, libgnutlsxx28 | libgnutlsxx30 | libgnutls30, libgpg-error0 (>= 1.10), zlib1g, libc1-net
 Description: Base library for Homegear
  Homegear is a program to interface your home automation software 
  with your smart home devices.


### PR DESCRIPTION
Ubuntu noble uses yet another name and doesnt follow debian with their libgnutlsxx30 naming scheme.